### PR TITLE
Import ECC, Hash, Schnorr, Types from Agora

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+# Build and run unit tests
+name: CI
+
+on: [ push, pull_request ]
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        dc: [ ldc-master, ldc-latest, ldc-1.20.0, dmd-latest, dmd-2.090.1 ]
+        exclude:
+          # https://github.com/dlang/dub/issues/1914
+          # https://github.com/dlang/dub/issues/1915
+          - { os: windows-2019, dc: dmd-latest }
+          - { os: windows-2019, dc: dmd-2.090.1 }
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dlang-community/setup-dlang@v1
+      with:
+        compiler: ${{ matrix.dc }}
+
+    - name: '[Linux] Install dependencies & setup environment'
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libsodium-dev
+
+    - name: '[Windows] Install dependencies'
+      if: runner.os == 'Windows' && steps.cache-libsodium.outputs.cache-hit != 'true'
+      run: |
+        # TODO: Read the version from the base ref
+        $url = "https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18-msvc.zip"
+        $sha256hash = "C1D48D85C9361E350931FFE5067559CD7405A697C655D26955FB568D1084A5F4"
+        Write-Host ('Downloading {0} ...' -f $url)
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        # See https://github.com/PowerShell/PowerShell/issues/2138
+        $ProgressPreference = 'SilentlyContinue'
+        New-Item -ItemType directory -Path ${{ github.workspace }}\lib\
+        Invoke-WebRequest -Uri $url -OutFile '${{ github.workspace }}\lib\libsodium.zip'
+        if ((Get-FileHash '${{ github.workspace }}\lib\libsodium.zip' -Algorithm "SHA256").Hash -ne $sha256hash) {
+          exit 1
+        }
+        Expand-Archive '${{ github.workspace }}\lib\libsodium.zip' -DestinationPath '${{ github.workspace }}\lib\'
+
+    - name: 'Build & Test'
+      if: runner.os != 'Windows'
+      run: |
+        dub test --compiler=$DC
+
+    - name: '[Windows] Build & test'
+      if: runner.os == 'Windows'
+      env:
+        LIB: ${{ github.workspace }}\lib\libsodium\x64\Release\v142\static\;$LIB
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        dub test --compiler=${{ env.DC }}
+        if %errorlevel% neq 0 exit /b %errorlevel%
+
+    - name: 'Upload code coverage'
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 docs.json
 __dummy.html
 docs/
+*-test-library
+dub.selections.json
 
 # Code coverage
 *.lst

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# schnorr
-A library to perform signature creation and validation using Schnorr on ed25519
+# Crypto
+
+A library to perform cryptographic operations for the BOA blockchain.
+The library relies on `libsodium` for cryptographic primitives,
+and the `bitblob` package for convenience.
+
+##  [`agora.crypto.Hash`](https://github.com/bpfkorea/crypto/blob/v0.x.x/source/agora/crypto/Hash.d)
+
+This module exposes a thin wrapper on top of `libsodiumd`'s `Blake2b` bindings,
+combining it with `bitblob` to provide a more user-friendly experience.
+The `Hash` type is a fully `@nogc` value type, and passing it to a string printing
+function that supports `toString` sink is guaranteed not to allocate.
+
+## [`agora.crypto.ECC`](https://github.com/bpfkorea/crypto/blob/v0.x.x/source/agora/crypto/ECC.d)
+
+This module exposes thin wrappers on top of `libsodium`'s cryptographic primitives,
+allowing to use more convenient syntax (e.g. operator overload) when manipulating scalar
+(numbers on finite field, usually used as private keys) and points (usually used as public key).
+
+## [`agora.crypto.Schnorr`](https://github.com/bpfkorea/crypto/blob/v0.x.x/source/agora/crypto/Schnorr.d)
+
+This module glues together `ECC` and `Hash` to generate `Signature`.
+TODO MORE.

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,15 @@
+{
+    "name": "crypto",
+    "description": "Library for cryptographic functions used by the BOA blockchain.",
+
+    "license": "MIT",
+    "authors": [ "BPF Korea" ],
+    "copyright": "Copyright © 2021, BPF Korea",
+
+    "targetType": "library",
+
+    "dependencies": {
+        "bitblob": "~>1.1",
+        "libsodiumd": "~>0.1.1+1.0.18"
+    }
+}

--- a/source/agora/crypto/ECC.d
+++ b/source/agora/crypto/ECC.d
@@ -1,0 +1,429 @@
+/*******************************************************************************
+
+    Elliptic-curve primitives
+
+    Those primitives are used for Schnorr signatures.
+
+    See_Also: https://en.wikipedia.org/wiki/EdDSA#Ed25519
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.crypto.ECC;
+
+import agora.crypto.Hash;
+import agora.crypto.Types;
+
+import geod24.bitblob;
+import libsodium;
+
+import std.format;
+
+///
+nothrow @nogc unittest
+{
+    const Scalar s1 = Scalar.random();
+    const Scalar s2 = Scalar.random();
+    const Scalar s3 = s1 + s2;
+
+    assert(s3 - s1 == s2);
+    assert(s3 - s2 == s1);
+    assert(s3 - s3 == Scalar.init);
+    assert(-s3 == -s1 - s2);
+    assert(-s3 == -s2 - s1);
+
+    const Scalar Zero = (s3 + (-s3));
+    assert(Zero == Scalar.init);
+
+    const Scalar One = (s3 + (~s3));
+    assert(One * One == One);
+
+    // Identity addition for Scalar
+    assert(Zero + One == One);
+    assert(One + Zero == One);
+
+    // Get the generator
+    const Point G = One.toPoint();
+    assert(G + G == (One + One).toPoint());
+
+    const Point p1 = s1.toPoint();
+    const Point p2 = s2.toPoint();
+    const Point p3 = s3.toPoint();
+
+    assert(s1.toPoint() == p1);
+    assert(p3 - p1 == p2);
+    assert(p3 - p2 == p1);
+
+    assert(s1 * p2 + s2 * p2 == s3 * p2);
+
+    // Identity addition for Point
+    const Point pZero = Point.init;
+
+    assert(pZero + G == G);
+    assert(G + pZero == G);
+}
+
+/*******************************************************************************
+
+    A field element in the finite field of order 2^255-19
+
+    Scalar are used as private key and source of noise for signatures.
+
+*******************************************************************************/
+
+public struct Scalar
+{
+    /// Internal state
+    package BitBlob!(crypto_core_ed25519_SCALARBYTES * 8) data;
+
+    private this (typeof(this.data) data) @safe
+    {
+        this.data = data;
+    }
+
+    /// Construct a scalar from its string representation or a `ubyte[]`
+    public this (T) (T param)
+        if (is(typeof(this.data = typeof(this.data)(param))))
+    {
+        this.data = typeof(this.data)(param);
+    }
+
+    /// Reduce the hash to a scalar
+    public this (Hash param) @trusted nothrow @nogc
+    {
+        static assert(typeof(data).sizeof == 32);
+        static assert(Hash.sizeof == 64);
+        crypto_core_ed25519_scalar_reduce(this.data[].ptr, param[].ptr);
+    }
+
+    /***************************************************************************
+
+        Print the scalar
+
+        By default, this function prints the hidden version of the scalar.
+        Changing the mode to `Clear` makes it print the original value.
+        This mode is intended for debugging.
+
+        Params:
+          sink = The sink to write the piecemeal string data to
+          mode = The `PrintMode` to use for printing the content.
+                 By default, the hidden value is printed.
+
+    ***************************************************************************/
+
+    public void toString (scope void delegate(in char[]) @safe sink,
+                          PrintMode mode = PrintMode.Obfuscated) const @safe
+    {
+        final switch (mode)
+        {
+        case PrintMode.Obfuscated:
+            formattedWrite(sink, "**SCALAR**");
+            break;
+
+        case PrintMode.Clear:
+            formattedWrite(sink, "%s", this.data);
+            break;
+        }
+    }
+
+    /// Ditto
+    public string toString (PrintMode mode = PrintMode.Obfuscated) const @safe
+    {
+        string result;
+        this.toString((data) { result ~= data; }, mode);
+        return result;
+    }
+
+    ///
+    unittest
+    {
+        auto s = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+
+        assert(s.toString(PrintMode.Obfuscated) == "**SCALAR**");
+        assert(s.toString(PrintMode.Clear) ==
+               "0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+
+        // Test default formatting behavior with writeln & format
+        import std.format : format;
+        assert(format("%s", s) == "**SCALAR**");
+    }
+
+    /// Vibe.d deserialization
+    public static Scalar fromString (in char[] str) @safe
+    {
+        return Scalar(typeof(this.data).fromString(str));
+    }
+
+    /// Operator overloads for `+`, `-`, `*`
+    public Scalar opBinary (string op)(const scope auto ref Scalar rhs)
+        const nothrow @nogc @trusted
+    {
+        // Point.init is Identity for functional operations
+        if (this == Scalar.init)
+            return rhs;
+        if (rhs == Scalar.init)
+            return this;
+        Scalar result = void;
+        static if (op == "+")
+            crypto_core_ed25519_scalar_add(
+                result.data[].ptr, this.data[].ptr, rhs.data[].ptr);
+        else static if (op == "-")
+            crypto_core_ed25519_scalar_sub(
+                result.data[].ptr, this.data[].ptr, rhs.data[].ptr);
+        else static if (op == "*")
+            crypto_core_ed25519_scalar_mul(
+                result.data[].ptr, this.data[].ptr, rhs.data[].ptr);
+        else
+            static assert(0, "Binary operator `" ~ op ~ "` not implemented");
+        return result;
+    }
+
+    /// Get the complement of this scalar
+    public Scalar opUnary (string s)()
+        const nothrow @nogc @trusted
+    {
+        Scalar result = void;
+        static if (s == "-")
+            crypto_core_ed25519_scalar_negate(result.data[].ptr, this.data[].ptr);
+        else static if (s == "~")
+            crypto_core_ed25519_scalar_complement(result.data[].ptr, this.data[].ptr);
+        else
+            static assert(0, "Unary operator `" ~ op ~ "` not implemented");
+        return result;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the inverted scalar.
+
+        See_Also:
+            https://libsodium.gitbook.io/doc/advanced/point-arithmetic
+            https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
+
+    ***************************************************************************/
+
+    public Scalar invert () const @nogc @trusted
+    {
+        Scalar scalar = this;  // copy
+        if (crypto_core_ed25519_scalar_invert(scalar.data[].ptr, this.data[].ptr) != 0)
+            assert(0);
+        return scalar;
+    }
+
+    /// Generate a random scalar
+    public static Scalar random () nothrow @nogc @trusted
+    {
+        Scalar ret = void;
+        crypto_core_ed25519_scalar_random(ret.data[].ptr);
+        return ret;
+    }
+
+    /// Scalar should be greater than zero and less than L:2^252 + 27742317777372353535851937790883648493
+    public bool isValid () nothrow @nogc @safe const
+    {
+        const auto ED25519_L =  BitBlob!256("0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed");
+        const auto ZERO =       BitBlob!256("0x0000000000000000000000000000000000000000000000000000000000000000");
+        return this.data > ZERO && this.data < ED25519_L;
+    }
+
+    /// Return the point corresponding to this scalar multiplied by the generator
+    public Point toPoint () const nothrow @nogc @trusted
+    {
+        Point ret = void;
+        if (crypto_scalarmult_ed25519_base_noclamp(ret.data[].ptr, this.data[].ptr) != 0)
+            assert(0, "Provided Scalar is not valid");
+        if (!ret.isValid)
+            assert(0, "libsodium generated invalid Point from valid Scalar!");
+        return ret;
+    }
+
+    /// Convenience overload to allow this to be converted to a BitBlob
+    public const(ubyte)[] opSlice () const @safe pure nothrow @nogc
+    {
+        return this.data[];
+    }
+}
+
+// Test Scalar fromString / toString functions
+@safe unittest
+{
+    static immutable string s = "0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec";
+    assert(Scalar.fromString(s).toString(PrintMode.Clear) == s);
+}
+
+// Test valid Scalars
+nothrow @nogc @safe unittest
+{
+    assert(Scalar(`0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec`).isValid);
+    assert(Scalar(`0x0eadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef`).isValid);
+    assert(Scalar(`0x0000000000000000000000000000000000000000000000000000000000000001`).isValid);
+}
+
+// Test invalid Scalars
+nothrow @nogc @safe unittest
+{
+    assert(!Scalar().isValid);
+    assert(!Scalar(`0x0000000000000000000000000000000000000000000000000000000000000000`).isValid);
+    assert(!Scalar(`0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed`).isValid);
+    assert(!Scalar(`0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef`).isValid);
+    assert(!Scalar(`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`).isValid);
+}
+
+/*******************************************************************************
+
+    Represent a point on Curve25519
+
+    A point is an element of the cyclic subgroup formed from the elliptic curve:
+    x^2 + y^2 = 1 - (121665 / 1216666) * x^2 * y^2
+    And the base point `B` where By=4/5 and Bx > 0.
+
+*******************************************************************************/
+
+public struct Point
+{
+    /// Internal state
+    package BitBlob!(crypto_core_ed25519_BYTES * 8) data;
+
+    private this (typeof(this.data) data) @safe @nogc pure nothrow
+    {
+        this.data = data;
+    }
+
+    /// Construct a point from its string representation or a `ubyte[]`
+    public this (T) (T param) nothrow @nogc
+        if (is(typeof(this.data = typeof(this.data)(param))))
+    {
+        this.data = typeof(this.data)(param);
+    }
+
+    /// Expose `toString`
+    public void toString (scope void delegate(in char[]) @safe dg)
+        const @safe
+    {
+        this.data.toString(dg);
+    }
+
+    /// Ditto
+    public string toString () const @safe
+    {
+        return this.data.toString();
+    }
+
+    /// Vibe.d deserialization
+    public static Point fromString (in char[] str) @safe
+    {
+        return Point(typeof(this.data).fromString(str));
+    }
+
+    /// Operator overloads for points additions
+    public Point opBinary (string op)(const scope auto ref Point rhs)
+        const nothrow @nogc @trusted
+        if (op == "+" || op == "-")
+    {
+        // Point.init is Identity for functional operations
+        if (this == Point.init)
+            return rhs;
+        if (rhs == Point.init)
+            return this;
+        Point result = void;
+        static if (op == "+")
+        {
+            if (crypto_core_ed25519_add(
+                    result.data[].ptr, this.data[].ptr, rhs.data[].ptr))
+                assert(0);
+        }
+        else static if (op == "-")
+        {
+            if (crypto_core_ed25519_sub(
+                    result.data[].ptr, this.data[].ptr, rhs.data[].ptr))
+                assert(0);
+        }
+        else static assert(0, "Unhandled `" ~ op ~ "` operator for Point");
+        return result;
+    }
+
+    /// Operator overloads for scalar multiplication
+    public Point opBinary (string op)(const scope auto ref Scalar rhs)
+        const nothrow @nogc @trusted
+        if (op == "*")
+    {
+        Point result = void;
+        if (crypto_scalarmult_ed25519_noclamp(
+                result.data[].ptr, rhs.data[].ptr, this.data[].ptr))
+            assert(0);
+        return result;
+    }
+
+    /// Ditto
+    public Point opBinaryRight (string op)(const scope auto ref Scalar lhs)
+        const nothrow @nogc @trusted
+        if (op == "*")
+    {
+        Point result = void;
+        if (crypto_scalarmult_ed25519_noclamp(
+                result.data[].ptr, lhs.data[].ptr, this.data[].ptr))
+            assert(0);
+        return result;
+    }
+
+    /// Convenience overload to allow this to be converted to a `PublicKey`
+    public const(ubyte)[] opSlice () const @safe pure nothrow @nogc
+    {
+        return this.data[];
+    }
+
+    /// Support for comparison
+    public int opCmp (ref const typeof(this) s) const
+    {
+        return this.data.opCmp(s.data);
+    }
+
+    /// Support for comparison (rvalue overload)
+    public int opCmp (const typeof(this) s) const
+    {
+        return this.data.opCmp(s.data);
+    }
+
+    // Validation that it is a valid point using libsodium
+    public bool isValid () nothrow @nogc @trusted const
+    {
+        return (crypto_core_ed25519_is_valid_point(this.data[].ptr) == 1);
+    }
+}
+
+// Test sorting (`opCmp`)
+unittest
+{
+    Point[] points = [
+        Point.fromString(
+            "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81"),
+        Point.fromString(
+            "0x37e8a197247dd01cc27c178dc0465ce826b4f6e312f3ee4c1df0623ef38c51c5")];
+
+    import std.algorithm : sort;
+    points.sort;
+    assert(points[0] == Point.fromString(
+            "0x37e8a197247dd01cc27c178dc0465ce826b4f6e312f3ee4c1df0623ef38c51c5"));
+}
+
+// Test validation
+unittest
+{
+    auto valid = Point.fromString("0xab4f6f6e85b8d0d38f5d5798a4bdc4dd444c8909c8a5389d3bb209a18610511b");
+    assert(valid.isValid());
+
+    // Add 1 to last byte of valid serialized Point to make it invalid
+    auto invalid = Point.fromString("0xab4f6f6e85b8d0d38f5d5798a4bdc4dd444c8909c8a5389d3bb209a18610511c");
+    assert(!invalid.isValid());
+
+    // Test initialized with no data is invalid
+    auto invalid2 = Point.init;
+    assert(!invalid2.isValid());
+}

--- a/source/agora/crypto/Hash.d
+++ b/source/agora/crypto/Hash.d
@@ -1,0 +1,296 @@
+/*******************************************************************************
+
+    Function definition and helper related to hashing
+
+    The actual definition of the `Hash` type is in `agora.common.Types`,
+    as parts of the system might pass along `Hash` without having to know
+    what / how they were produced.
+
+    However, this module expose functionalities for modules that want to do
+    hashing. The interface is designed so that this module knows about the
+    hash types, and aggregates implementing the interface only deal with their
+    members.
+
+    Due to a language limitation (one can't overload based on return value),
+    this module expose two main functions:
+    - `hashFull(T)`, which returns a `Hash`
+    - `hashPart(T, HashDg)` which does not return anything and should be used
+      to accumulate data to hash.
+
+    For safety reason, a data structure currently need to explicitly define
+    a `hash` function to support hashing.
+    This limitation might be lifted in the future, but a few things
+    need to be taken into account:
+    - Alignment / packing: We can't have unaligned / unpacked structures
+      as it would create malleability issues
+    - Non-public members: We can't deal with anything non-public (we can use
+      `.tupleof` but it's impossible to tell the usage of the member,
+      e.g. it could be a cache of the hash)
+    - Indirections / references types
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.crypto.Hash;
+
+public import agora.crypto.Types;
+
+import libsodium;
+
+import std.bitmanip : nativeToLittleEndian;
+
+///
+nothrow @nogc @safe unittest
+{
+    static struct SimpleStruct
+    {
+        ulong foo;
+        string bar;
+    }
+
+    static struct ComplexStruct
+    {
+        string irrelevant;
+        string bar;
+        ulong foo;
+
+        void computeHash (scope HashDg dg) const nothrow @safe @nogc
+        {
+            // We can hash in any order we want, and ignore anything we want
+            hashPart(this.foo, dg);
+            hashPart(this.bar, dg);
+        }
+    }
+
+    const st = SimpleStruct(42, "42");
+    // This gives the same result as if `foo` and the content of `bar` were
+    // stored contiguously in memory and hashed
+    Hash r2 = hashFull(st);
+    // Result is stable
+    assert(hashFull(SimpleStruct(42, "42")) == r2);
+    assert(hashFull(ComplexStruct("Hello World", "42", 42)) == r2);
+
+    // Alternatively, simple string messages can be hashed
+    Hash abc = hashFull("abc");
+
+    // And any basic type
+    Hash ulm = hashFull(ulong.max);
+}
+
+/// Type of delegate passed to `hash` function when there's a state
+public alias HashDg = void delegate(in ubyte[]) /*pure*/ nothrow @safe @nogc;
+
+
+/*******************************************************************************
+
+    Hash a given data structure using BLAKE2b into `state`
+
+    Note that there is no overload for signed types, as only the binary
+    representation matters for hashing.
+
+    Params:
+      T = Type of struct to hash
+      record = Instance of `T` to hash
+      state  = State delegate, when this struct is nested in another.
+
+    Returns:
+      The `Hash` representing this instance
+
+*******************************************************************************/
+
+public Hash hashFull (T) (scope const auto ref T record)
+    nothrow @nogc @trusted
+{
+    Hash hash = void;
+    crypto_generichash_state state;
+    crypto_generichash_init(&state, null, 0, Hash.sizeof);
+    scope HashDg dg = (scope const(ubyte)[] data) @trusted
+                     => cast(void)crypto_generichash_update(&state, data.ptr, data.length);
+    hashPart(record, dg);
+    crypto_generichash_final(&state, hash[].ptr, Hash.sizeof);
+    return hash;
+}
+
+/// Ditto
+public void hashPart (T) (scope const auto ref T record, scope HashDg state)
+    /*pure*/ nothrow @nogc
+    if (is(T == struct))
+{
+    static if (is(typeof(T.init.computeHash(HashDg.init))))
+        record.computeHash(state);
+    else static if (__traits(compiles, () { const ubyte[] r = T.init[]; }))
+        state(record[]);
+    else
+        foreach (const ref field; record.tupleof)
+            hashPart(field, state);
+}
+
+/// Ditto
+public void hashPart (ubyte record, scope HashDg state) /*pure*/ nothrow @nogc @trusted
+{
+    state((cast(ubyte*)&record)[0 .. ubyte.sizeof]);
+}
+
+/// Ditto
+public void hashPart (ushort record, scope HashDg state) /*pure*/ nothrow @nogc @trusted
+{
+    state(nativeToLittleEndian(record)[0 .. ushort.sizeof]);
+}
+
+/// Ditto
+public void hashPart (uint record, scope HashDg state) /*pure*/ nothrow @nogc @trusted
+{
+    state(nativeToLittleEndian(record)[0 .. uint.sizeof]);
+}
+
+/// Ditto
+public void hashPart (ulong record, scope HashDg state) /*pure*/ nothrow @nogc @trusted
+{
+    state(nativeToLittleEndian(record)[0 .. ulong.sizeof]);
+}
+
+/// Ditto
+public void hashPart (in char[] record, scope HashDg state) /*pure*/ nothrow @nogc @trusted
+{
+    state(cast(const ubyte[])record);
+}
+
+/// Ditto
+public void hashPart (in ubyte[] record, scope HashDg state)
+    /*pure*/ nothrow @nogc @safe
+{
+    state(record);
+}
+
+/// Ditto
+public void hashPart (T) (in T[] records, scope HashDg state)
+    /*pure*/ nothrow @nogc @safe
+{
+    foreach (ref record; records)
+        hashPart(record, state);
+}
+
+// Endianness test
+unittest
+{
+    assert(hashFull(0x0102).toString()             == "0xcab9b7ff335bf7ce6e801192cf57ec97a97d91d84de93201399ffa17cd2cd07" ~
+                                                      "1fcd7cd62d92b5fa5cc4de8bb4dd7a556cf524a9c597cdb5a8917aaf119eded8c");
+    assert(hashFull(0x01020304).toString()         == "0xe01ad62eb0275971a2973ba15f44b0b90e2da88d871ba4fda1430353b4cfe290" ~
+                                                      "3555d974665b42e34805c9730249a0905f5b433e1cb97f91e1292bb7264b4ecb");
+    assert(hashFull(0x0102030405060708).toString() == "0xcda1a14d4efa540dd742bd7a0018823063ece39955b59d6b2ac507ac32f7e06" ~
+                                                      "410c64a6334e044508855e86e3c51ca53903371937edfeb8a74fa6a848baae93f");
+}
+// Test that the implementation actually matches what the RFC gives
+nothrow @nogc @safe unittest
+{
+    // https://tools.ietf.org/html/rfc7693#appendix-A
+    static immutable ubyte[] hdata = [
+        0xBA, 0x80, 0xA5, 0x3F, 0x98, 0x1C, 0x4D, 0x0D, 0x6A, 0x27, 0x97, 0xB6,
+        0x9F, 0x12, 0xF6, 0xE9,
+        0x4C, 0x21, 0x2F, 0x14, 0x68, 0x5A, 0xC4, 0xB7, 0x4B, 0x12, 0xBB, 0x6F,
+        0xDB, 0xFF, 0xA2, 0xD1,
+        0x7D, 0x87, 0xC5, 0x39, 0x2A, 0xAB, 0x79, 0x2D, 0xC2, 0x52, 0xD5, 0xDE,
+        0x45, 0x33, 0xCC, 0x95,
+        0x18, 0xD3, 0x8A, 0xA8, 0xDB, 0xF1, 0x92, 0x5A, 0xB9, 0x23, 0x86, 0xED,
+        0xD4, 0x00, 0x99, 0x23
+    ];
+    const abc_exp = Hash(hdata, /*isLittleEndian:*/ true);
+    assert(hashFull("abc") == abc_exp);
+
+    static struct Composed
+    {
+        public char c0;
+        private int irrelevant;
+        public char c1;
+        private ulong say_what;
+        public char c2;
+        private string baguette;
+
+        public void computeHash (scope HashDg dg) const nothrow @safe @nogc
+        {
+            // We can hash in any order we want
+            hashPart(this.c0, dg);
+            hashPart(this.c1, dg);
+            hashPart(this.c2, dg);
+        }
+    }
+
+    Composed str;
+    str.c0 = 'a';
+    str.c1 = 'b';
+    str.c2 = 'c';
+    assert(hashFull(str) == abc_exp);
+}
+
+/*******************************************************************************
+
+    Hashes multiple arguments together
+
+    Params:
+        T = variadic argument types
+        args = the arguments
+
+    Returns:
+        the hash of all the arguments
+
+*******************************************************************************/
+
+public Hash hashMulti (T...)(auto ref T args) nothrow @nogc @safe
+{
+    Hash hash = void;
+    crypto_generichash_state state;
+
+    auto dg = () @trusted {
+        crypto_generichash_init(&state, null, 0, Hash.sizeof);
+        scope HashDg dg = (scope const(ubyte)[] data) @trusted
+            => cast(void)crypto_generichash_update(&state, data.ptr, data.length);
+        return dg;
+    }();
+
+    static foreach (idx, _; args)
+        hashPart(args[idx], dg);
+    () @trusted { crypto_generichash_final(&state, hash[].ptr, Hash.sizeof); }();
+    return hash;
+}
+
+///
+nothrow @nogc @safe unittest
+{
+    Hash foo = hashFull("foo");
+    Hash bar = hashFull("bar");
+    const merged = Hash(
+        "0xe0343d063b14c52630563ec81b0f91a84ddb05f2cf05a2e4330ddc79bd3a06e57" ~
+        "c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74");
+
+    assert(hashMulti(foo, bar) == merged);
+
+    const Hash[2] array = [foo, bar];
+    assert(hashFull(array[]) == merged);
+
+    static struct S
+    {
+        public char c0;
+        private int unused_1;
+        public char c1;
+        private int unused_2;
+        public char c2;
+        private int unused_3;
+
+        public void computeHash (scope HashDg dg) const nothrow @safe @nogc
+        {
+            hashPart(this.c0, dg);
+            hashPart(this.c1, dg);
+            hashPart(this.c2, dg);
+        }
+    }
+
+    auto hash_1 = hashMulti(420, "bpfk", S('a', 0, 'b', 0, 'c', 0));
+    auto hash_2 = hashMulti(420, "bpfk", S('a', 1, 'b', 2, 'c', 3));
+    assert(hash_1 == hash_2);
+}

--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -1,0 +1,528 @@
+/*******************************************************************************
+
+    Low level utilities to perform Schnorr signatures on Curve25519.
+
+    Through this module, lowercase letters represent scalars and uppercase
+    letters represent points. Multiplication of a scalar by a point,
+    which is adding a point to itself multiple times, is represented with '*',
+    e.g. `a * G`. Uppercase letters are point representations of scalars,
+    that is, the scalar multipled by the generator, e.g. `r == r * G`.
+    `x` is the private key, `X` is the public key, and `H()` is the Blake2b
+    512 bits hash reduced to a scalar in the field.
+
+    Following the Schnorr BIP (see links), signatures are of the form
+    `(R,s)` and satisfy `s * G = R + H(X || R || m) * X`.
+    `r` is refered to as the nonce and is a cryptographically randomly
+    generated number that should neither be reused nor leaked.
+
+    Signature_Aggregation:
+    Since Schnorr signatures use a linear equation, they can be simply
+    combined with addition, enabling `O(1)` signature verification
+    time and `O(1)` and `O(1)` signature size.
+    Additionally, since the `c` factor does not depend on EC operation,
+    we can do batch verification, enabling us to speed up verification
+    when verifying large amount of data (e.g. a block).
+
+    See_Also:
+      - https://en.wikipedia.org/wiki/Curve25519
+      - https://en.wikipedia.org/wiki/Schnorr_signature
+      - https://medium.com/blockstream/reducing-bitcoin-transaction-sizes-with-x-only-pubkeys-f86476af05d7
+
+    TODO:
+      - Audit GDC and LDC generated code
+      - Proper audit
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.crypto.Schnorr;
+
+import agora.crypto.Types;
+import agora.crypto.Hash;
+import agora.crypto.ECC;
+
+import std.algorithm;
+import std.range;
+
+
+/// Single signature example
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.random();
+    auto signature = sign(kp, "Hello world");
+    assert(verify(kp.V, signature, "Hello world"));
+}
+
+/// Multi-signature example
+nothrow @nogc @safe unittest
+{
+    // Setup
+    static immutable string secret = "BOSAGORA for the win";
+    Pair kp1 = Pair.random();
+    Pair kp2 = Pair.random();
+    Pair R1 = Pair.random();
+    Pair R2 = Pair.random();
+    Point R = R1.V + R2.V;
+    Point X = kp1.V + kp2.V;
+
+    const sig1 = sign(kp1.v, X, R, R1.v, secret);
+    const sig2 = sign(kp2.v, X, R, R2.v, secret);
+    const sig3 = Sig(R, Sig.fromBlob(sig1).s + Sig.fromBlob(sig2).s).toBlob();
+
+    // No one can verify any of those individually
+    assert(!verify(kp1.V, sig1, secret));
+    assert(!verify(kp1.V, sig2, secret));
+    assert(!verify(kp2.V, sig2, secret));
+    assert(!verify(kp2.V, sig1, secret));
+    assert(!verify(kp1.V, sig3, secret));
+    assert(!verify(kp2.V, sig3, secret));
+
+    // But multisig works
+    assert(verify(X, sig3, secret));
+}
+
+/*******************************************************************************
+
+    Extract the R from (R, s) of a binary representation of a signature
+
+    Params:
+        sig = the binary representation of the schnorr signature
+
+    Returns:
+        the R from the (R, s) pair
+
+*******************************************************************************/
+
+public Point extractNonce (Signature sig) @safe @nogc nothrow pure
+{
+    return Sig.fromBlob(sig).R;
+}
+
+///
+@safe @nogc nothrow /*pure*/ unittest
+{
+    const R = Pair.random();
+    const kp = Pair.random();
+    const sig = sign(kp.v, kp.V, R.V, R.v, "foo");
+    assert(extractNonce(sig) == R.V);
+}
+
+/*******************************************************************************
+    Represent a signature (R, s)
+
+    Note that signatures get passed around as binary blobs
+    (see `agora.common.Types`), so this type is named `Sig` to avoid ambiguity.
+
+*******************************************************************************/
+
+public struct Sig
+{
+    /// Commitment
+    public Point R;
+    /// Proof
+    public Scalar s;
+
+    static assert(Signature.sizeof == typeof(this).sizeof);
+
+    /// Converts this signature to a BitBlob matching `agora.common.Types`
+    public Signature toBlob () const pure nothrow @nogc @safe
+    {
+        typeof(return) ret;
+        ret[0 .. Point.sizeof][] = this.R.data[];
+        ret[Point.sizeof .. $][] = this.s.data[];
+        return ret;
+    }
+
+    /// Deserialize a binary blob into a signature
+    public static Sig fromBlob (const ref Signature s) pure nothrow @nogc @safe
+    {
+        return Sig(Point(s[0 .. Point.sizeof]), Scalar(s[Point.sizeof .. $]));
+    }
+}
+
+/// Represent the message to hash (part of `c`)
+private struct Message (T)
+{
+    public Point X;
+    public Point R;
+    public T     message;
+}
+
+/// Contains a scalar and its projection on the elliptic curve (`v` and `v.G`)
+public struct Pair
+{
+    /// A PRNGenerated number
+    public Scalar v;
+    /// v.G
+    public Point V;
+
+    /// Construct a Pair from a Scalar
+    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe
+    {
+        return Pair(v, v.toPoint());
+    }
+
+    /// Generate a random value `v` and a point on the curve `V` where `V = v.G`
+    public static Pair random () nothrow @nogc @safe
+    {
+        return Pair.fromScalar(Scalar.random());
+    }
+}
+
+// Test constructing Pair from scalar
+unittest
+{
+    const Scalar s = Scalar.random();
+    const pair1 = Pair(s, s.toPoint());
+    const pair2 = Pair.fromScalar(s);
+    assert(pair1 == pair2);
+}
+
+/// Single-signer trivial API
+public Signature sign (T) (const ref Pair kp, auto ref T data)
+    nothrow @nogc @safe
+{
+    const R = Pair.random();
+    return sign!T(kp.v, kp.V, R.V, R.v, data);
+}
+
+/// Single-signer privkey API
+public Signature sign (T) (const ref Scalar privateKey, T data)
+    nothrow @nogc @safe
+{
+    const R = Pair.random();
+    return sign!T(privateKey, privateKey.toPoint(), R.V, R.v, data);
+}
+
+/// Sign with a given `r` (warning: `r` should never be reused with `x`)
+public Signature sign (T) (const ref Pair kp, const ref Pair r, auto ref T data)
+{
+    return sign!T(kp.v, kp.V, r.V, r.v, data);
+}
+
+/// Complex API, allow multisig
+public Signature sign (T) (
+    const ref Scalar x, const ref Point X,
+    const ref Point R, const ref Scalar r,
+    auto ref T data)
+    nothrow @nogc @trusted
+{
+    /*
+      G := Generator point:
+      15112221349535400772501151409588531511454012693041857206046113283949847762202,
+      46316835694926478169428394003475163141307993866256225615783033603165251855960
+      x := private key
+      X := public key (x.G)
+      r := random number
+      R := commitment (r.G)
+      c := Hash(X || R || message)
+
+      Proof = (R, s)
+      Signature/Verify: R + c*X == s.G
+      Multisig:
+      R = (r0 + r1 + rn).G == (R0 + R1 + Rn)
+      X = (X0 + X1 + Xn)
+      To get `c`, need to precommit `R`
+     */
+    // Compute the challenge and reduce the hash to a scalar
+    Scalar c = hashFull(Message!T(X, R, data));
+    // Compute `s` part of the proof
+    Scalar s = r + (c * x);
+    return Sig(R, s).toBlob();
+}
+
+/*******************************************************************************
+
+    Verify that a signature matches the provided data
+
+    Params:
+      T = Type of data being signed
+      X = The point corresponding to the public key
+      sig = Signature to verify
+      data = Data to sign (the hash will be signed)
+
+    Returns:
+      Whether or not the signature is valid for (X, s, data).
+
+*******************************************************************************/
+
+public bool verify (T) (const ref Point X, const ref Signature sig, auto ref T data)
+    nothrow @nogc @trusted
+{
+    Sig s = Sig.fromBlob(sig);
+    // First check if Scalar from signature is valid
+    if (!s.s.isValid())
+        return false;
+    /// Compute `s.G`
+    auto S = s.s.toPoint();
+    // Now check that provided Point X is valid
+    if (!X.isValid())
+        return false;
+    // Also check the Point R from the Signature
+    if (!s.R.isValid())
+        return false;
+    // Compute the challenge and reduce the hash to a scalar
+    Scalar c = hashFull(Message!T(X, s.R, data));
+    // Compute `R + c*X`
+    Point RcX = s.R + (c * X);
+    return S == RcX;
+}
+
+// Valid signing test with valid scalar
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`));
+    static immutable string message = "Bosagora:-)";
+    auto signature = sign(kp, message);
+    assert(verify(kp.V, signature, message));
+}
+
+// Valid with scalar value 1
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x0000000000000000000000000000000000000000000000000000000000000001`));
+    static immutable string message = "Bosagora:-)";
+    auto signature = sign(kp, message);
+    assert(verify(kp.V, signature, message));
+}
+
+// Largest value for Scalar. One less than Ed25519 prime order l where l=2^252 + 27742317777372353535851937790883648493
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec`));
+    static immutable string message = "Bosagora:-)";
+    auto signature = sign(kp, message);
+    assert(verify(kp.V, signature, message));
+}
+
+// Not valid with blank signature
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`));
+    static immutable string message = "Bosagora:-)";
+    Signature signature;
+    assert(!verify(kp.V, signature, message));
+}
+
+nothrow @nogc @safe unittest
+{
+    static immutable string secret = "BOSAGORA for the win";
+    Pair kp1 = Pair.random();
+    Pair kp2 = Pair.random();
+    auto sig1 = sign(kp1, secret);
+    auto sig2 = sign(kp2, secret);
+    assert(verify(kp1.V, sig1, secret));
+    assert(!verify(kp1.V, sig2, secret));
+    assert(verify(kp2.V, sig2, secret));
+    assert(!verify(kp2.V, sig1, secret));
+}
+
+// invalid signing test with invalid Public Key Point X
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`));
+    static immutable string message = "Bosagora:-)";
+    auto signature = sign(kp, message);
+    auto invalid = Point("0xab4f6f6e85b8d0d38f5d5798a4bdc4dd444c8909c8a5389d3bb209a18610511c");
+    assert(!verify(invalid, signature, message));
+}
+
+// invalid signing test with invalid Point R in Signature
+nothrow @nogc @safe unittest
+{
+    Pair kp = Pair.fromScalar(Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`));
+    static immutable string message = "Bosagora:-)";
+    auto signature = sign(kp, message);
+    Signature invalid_sig = Sig(Point("0xab4f6f6e85b8d0d38f5d5798a4bdc4dd444c8909c8a5389d3bb209a18610511c"),
+        Sig.fromBlob(signature).s).toBlob();
+    assert(!verify(kp.V, invalid_sig, message));
+}
+
+// example of extracting the private key from an insecure signature scheme
+// which did not include 'r' during the signing
+// https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
+/*@nogc*/ @safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    Pair kp = Pair.random();  // key-pair
+    Scalar c = hashFull(message);  // challenge
+    Scalar s = (kp.v * c);  // signature
+
+    // known public data of the node
+    Point K = kp.V;
+
+    // other nodes verify
+    assert(s.toPoint() == K * c);
+
+    // but the other node can also extract the private key!
+    Scalar stolen_key = s * c.invert();
+    assert(stolen_key == kp.v);
+}
+
+// possibly secure signature scheme (requires proving ownership of private key)
+/*@nogc*/ @safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    Pair kp = Pair.random();  // key-pair
+    Pair Rp = Pair.random();  // (R, r), the public and private nonce
+    Scalar c = hashFull(message);  // challenge
+    Scalar s = Rp.v + (kp.v * c);  // signature
+
+    // known public data of the node
+    Point K = kp.V;
+    Point R = Rp.V;
+
+    // other nodes verify
+    assert(s.toPoint() == R + (K * c));
+
+    // other nodes cannot extract the private key, they don't know 'r'
+    Scalar stolen_key = s * c.invert();
+    assert(stolen_key != kp.v);
+}
+
+/// Single-signer as part of multi-sig
+public Scalar multiSigSign (const ref Scalar r,
+    const ref Scalar v, const ref Scalar c) nothrow @nogc @safe
+{
+    return r + (v * c);
+}
+
+/// multi-sig verify
+public bool multiSigVerify (const ref Sig sig,
+    const ref Point sumV, const ref Scalar c) nothrow @nogc @safe
+{
+    return sig.s.toPoint() == sig.R + (sumV * c);
+}
+
+/// multi-sig combine
+public Sig multiSigCombine (S)(const S sigs) nothrow @nogc @safe
+{
+    Point sum_R = sigs.map!(x => x.R).sum(Point.init);
+    Scalar sum_s = sigs.map!(x => x.s).sum(Scalar.init);
+    return Sig(sum_R, sum_s);
+}
+
+/// testing multiSig for block signing
+/*@nogc*/ @safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    const Scalar c = hashFull(message);  // challenge
+
+    const kp1_K = Pair.random();  // key-pair
+    const kp1_R = Pair.random();  // (R, r), the public and private nonce
+
+    // first signer
+    const Scalar s1 = multiSigSign(kp1_R.v, kp1_K.v, c);
+
+    const kp2_K = Pair.random();  // key-pair
+    const kp2_R = Pair.random();  // (R, r), the public and private nonce
+
+    // second signer
+    const Scalar s2 = multiSigSign(kp2_R.v, kp2_K.v, c);
+
+    // verification of individual signatures
+    assert(s1.toPoint() == kp1_R.V + (kp1_K.V * c));
+    assert(s2.toPoint() == kp2_R.V + (kp2_K.V * c));
+
+    Sig[] sigs = [ Sig(kp1_R.V, s1), Sig(kp2_R.V, s2) ];
+    // "multi-sig" - collection of one or more signatures
+    Sig two_sigs = multiSigCombine(sigs);
+
+    const sumK = kp1_K.V + kp2_K.V;
+    // verification of combined signatures
+    assert(multiSigVerify(two_sigs, sumK, c));
+
+    // Now add one more signature
+    const kp3_K = Pair.random();  // key-pair
+    const kp3_R = Pair.random();  // (R, r), the public and private nonce
+
+    // third signer
+    const Scalar s3 = multiSigSign(kp3_R.v, kp3_K.v, c);
+    // Add third signature
+    Sig three_sigs = multiSigCombine([ two_sigs, Sig(kp3_R.V, s3) ]);
+    // verification of updated combined signatures
+    const three_sumK = sumK + kp3_K.V;
+    assert(multiSigVerify(three_sigs, three_sumK, c));
+}
+
+// rogue-key attack
+// see: https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#key-cancellation-attack
+// see: https://blockstream.com/2018/01/23/en-musig-key-aggregation-schnorr-signatures/#:~:text=not%20secure.
+@safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    // alice
+    const Pair kp1 = Pair.random(); // key-pair
+    const Pair R1 = Pair.random();  // (R, r), the public and private nonce
+
+    // bob
+    const Pair kp2 = Pair.random(); // ditto
+    const Pair R2 = Pair.random();  // ditto
+
+    auto R = R1.V + R2.V;
+    auto X = kp1.V + kp2.V;
+    Scalar c = hashMulti(X, R, message);  // challenge
+
+    Scalar s1 = R1.v + (kp1.v * c);
+    Scalar s2 = R2.v + (kp2.v * c);
+    Scalar multi_sig = s1 + s2;
+    assert(multi_sig.toPoint() == R + (X * c));
+
+    // now assume that bob lied about his V and R during the co-operative phase.
+    auto bobV = kp2.V - kp1.V;
+    auto bobR = R2.V - R1.V;
+    X = kp1.V + bobV;
+    R = R1.V + bobR;
+    c = Scalar(hashMulti(X, R, message));
+
+    // bob signed the message alone, without co-operation from alice. it passes!
+    Scalar bob_sig = R2.v + (kp2.v * c);
+    assert(bob_sig.toPoint() == R + (X * c));
+}
+
+// ditto, but using multi-sig
+/*@nogc*/ @safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    Scalar c = hashFull(message);  // challenge
+
+    Pair kp_1 = Pair.random();  // key-pair
+    Pair Rp_1 = Pair.random();  // (R, r), the public and private nonce
+    Scalar s_1 = Rp_1.v + (kp_1.v * c);  // signature
+
+    Pair kp_2 = Pair.random();  // key-pair
+    Pair Rp_2 = Pair.random();  // (R, r), the public and private nonce
+    Scalar s_2 = Rp_2.v + (kp_2.v * c);  // signature
+
+    // known public data of the nodes
+    Point K_1 = kp_1.V;
+    Point R_1 = Rp_1.V;
+
+    Point K_2 = kp_2.V;
+    Point R_2 = Rp_2.V;
+
+    // verification of individual signatures
+    assert(s_1.toPoint() == R_1 + (K_1 * c));
+    assert(s_2.toPoint() == R_2 + (K_2 * c));
+
+    // "multi-sig" - collection of one or more signatures
+    auto sum_s = s_1 + s_2;
+    assert(sum_s.toPoint() ==
+        (R_1 + (K_1 * c)) +
+        (R_2 + (K_2 * c)));
+
+    // Or the equivalent:
+    assert(sum_s.toPoint() ==
+        (R_1 + R_2) + (K_1 * c) + (K_2 * c));
+}

--- a/source/agora/crypto/Types.d
+++ b/source/agora/crypto/Types.d
@@ -1,0 +1,44 @@
+/*******************************************************************************
+
+    Define the types used by this library
+
+    This module is separate from `agora.crypto.Hash` and others to allow
+    lightweight imports in client code, as well as to embbed a `Hash` into
+    a `struct` without adding a dependency to the hashing code.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.crypto.Types;
+
+import geod24.bitblob;
+
+/// 512 bits hash type computed via `BLAKE2b`
+public alias Hash = BitBlob!512;
+
+/// The type of a signature
+public alias Signature = BitBlob!512;
+
+unittest
+{
+    // Check that our type match libsodium's definition
+    import libsodium;
+
+    static assert(Signature.sizeof == crypto_sign_ed25519_BYTES);
+    static assert(Hash.sizeof == crypto_generichash_BYTES_MAX);
+}
+
+/// Describe print modes for `toString`
+public enum PrintMode
+{
+    /// Print hidden version
+    Obfuscated,
+    /// Print original value
+    Clear,
+}


### PR DESCRIPTION
Those modules can live in their own library and do not need to be in Agora.

I will do a pass over the README (which is clearly incomplete) and the comments in general.