### PR TITLE
Make the API use 'in' for small types and auto ref

### DIFF
--- a/source/agora/crypto/ECC.d
+++ b/source/agora/crypto/ECC.d
@@ -161,7 +161,7 @@ public struct Scalar
     }
 
     /// Operator overloads for `+`, `-`, `*`
-    public Scalar opBinary (string op)(const scope auto ref Scalar rhs)
+    public Scalar opBinary (string op)(in Scalar rhs)
         const nothrow @nogc @trusted
     {
         // Point.init is Identity for functional operations
@@ -323,7 +323,7 @@ public struct Point
     }
 
     /// Operator overloads for points additions
-    public Point opBinary (string op)(const scope auto ref Point rhs)
+    public Point opBinary (string op)(in Point rhs)
         const nothrow @nogc @trusted
         if (op == "+" || op == "-")
     {
@@ -350,7 +350,7 @@ public struct Point
     }
 
     /// Operator overloads for scalar multiplication
-    public Point opBinary (string op)(const scope auto ref Scalar rhs)
+    public Point opBinary (string op)(in Scalar rhs)
         const nothrow @nogc @trusted
         if (op == "*")
     {
@@ -362,7 +362,7 @@ public struct Point
     }
 
     /// Ditto
-    public Point opBinaryRight (string op)(const scope auto ref Scalar lhs)
+    public Point opBinaryRight (string op)(in Scalar lhs)
         const nothrow @nogc @trusted
         if (op == "*")
     {

--- a/source/agora/crypto/Hash.d
+++ b/source/agora/crypto/Hash.d
@@ -111,7 +111,7 @@ public Hash hashFull (T) (scope const auto ref T record)
     Hash hash = void;
     crypto_generichash_state state;
     crypto_generichash_init(&state, null, 0, Hash.sizeof);
-    scope HashDg dg = (scope const(ubyte)[] data) @trusted {
+    scope HashDg dg = (in ubyte[] data) @trusted {
         crypto_generichash_update(&state, data.ptr, data.length);
     };
     hashPart(record, dg);
@@ -233,7 +233,7 @@ public Hash hashMulti (T...)(auto ref T args) nothrow @nogc @safe
 
     auto dg = () @trusted {
         crypto_generichash_init(&state, null, 0, Hash.sizeof);
-        scope HashDg dg = (scope const(ubyte)[] data) @trusted {
+        scope HashDg dg = (in ubyte[] data) @trusted {
             crypto_generichash_update(&state, data.ptr, data.length);
         };
         return dg;

--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -140,7 +140,7 @@ public struct Sig
     }
 
     /// Deserialize a binary blob into a signature
-    public static Sig fromBlob (const ref Signature s) pure nothrow @nogc @safe
+    public static Sig fromBlob (in Signature s) pure nothrow @nogc @safe
     {
         return Sig(Point(s[0 .. Point.sizeof]), Scalar(s[Point.sizeof .. $]));
     }
@@ -163,7 +163,7 @@ public struct Pair
     public Point V;
 
     /// Construct a Pair from a Scalar
-    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe
+    public static Pair fromScalar(in Scalar v) nothrow @nogc @safe
     {
         return Pair(v, v.toPoint());
     }
@@ -185,7 +185,7 @@ unittest
 }
 
 /// Single-signer trivial API
-public Signature sign (T) (const ref Pair kp, auto ref T data)
+public Signature sign (T) (in Pair kp, scope const auto ref T data)
     nothrow @nogc @safe
 {
     const R = Pair.random();
@@ -193,7 +193,7 @@ public Signature sign (T) (const ref Pair kp, auto ref T data)
 }
 
 /// Single-signer privkey API
-public Signature sign (T) (const ref Scalar privateKey, T data)
+public Signature sign (T) (in Scalar privateKey, scope const auto ref T data)
     nothrow @nogc @safe
 {
     const R = Pair.random();
@@ -201,16 +201,14 @@ public Signature sign (T) (const ref Scalar privateKey, T data)
 }
 
 /// Sign with a given `r` (warning: `r` should never be reused with `x`)
-public Signature sign (T) (const ref Pair kp, const ref Pair r, auto ref T data)
+public Signature sign (T) (in Pair kp, in Pair r, scope const auto ref T data)
 {
     return sign!T(kp.v, kp.V, r.V, r.v, data);
 }
 
 /// Complex API, allow multisig
 public Signature sign (T) (
-    const ref Scalar x, const ref Point X,
-    const ref Point R, const ref Scalar r,
-    auto ref T data)
+    in Scalar x, in Point X, in Point R, in Scalar r, scope const auto ref T data)
     nothrow @nogc @trusted
 {
     /*
@@ -252,7 +250,7 @@ public Signature sign (T) (
 
 *******************************************************************************/
 
-public bool verify (T) (const ref Point X, const ref Signature sig, auto ref T data)
+public bool verify (T) (in Point X, in Signature sig, scope const auto ref T data)
     nothrow @nogc @trusted
 {
     Sig s = Sig.fromBlob(sig);
@@ -389,15 +387,15 @@ nothrow @nogc @safe unittest
 }
 
 /// Single-signer as part of multi-sig
-public Scalar multiSigSign (const ref Scalar r,
-    const ref Scalar v, const ref Scalar c) nothrow @nogc @safe
+public Scalar multiSigSign (in Scalar r, in Scalar v, in Scalar c)
+    nothrow @nogc @safe
 {
     return r + (v * c);
 }
 
 /// multi-sig verify
-public bool multiSigVerify (const ref Sig sig,
-    const ref Point sumV, const ref Scalar c) nothrow @nogc @safe
+public bool multiSigVerify (in Sig sig, in Point sumV, in Scalar c)
+    nothrow @nogc @safe
 {
     return sig.s.toPoint() == sig.R + (sumV * c);
 }


### PR DESCRIPTION
This prepares for the transition to use 'in' with '-preview=in'.
We still use 'auto ref' for templated types, as they could be
arbitrarily large, but otherwise 'in' is used everywhere.