### PR TITLE
Hash array lengths

### DIFF
--- a/source/agora/crypto/Hash.d
+++ b/source/agora/crypto/Hash.d
@@ -134,18 +134,28 @@ public void hashPart (T) (scope const auto ref T record, scope HashDg hasher)
 
     static if (is(typeof(T.init.computeHash(HashDg.init))))
         record.computeHash(hasher);
+
     else static if (__traits(compiles, () { const ubyte[] r = T.init[]; }))
+    {
+        hashVarInt(record[].length, hasher);
         hasher(record[]);
-
+    }
     else static if (isNarrowString!T)
+    {
+        hashVarInt(record.length, hasher);
         hasher(cast(const(ubyte[]))record);
+    }
     else static if (is(immutable(T) == immutable(ubyte[])))
+    {
+        hashVarInt(record.length, hasher);
         hasher(record);
-
+    }
     else static if (is(T : E[], E))
+    {
+        hashVarInt(record.length, hasher);
         foreach (ref r; record)
             hashPart(r, hasher);
-
+    }
     else static if (is(immutable(ubyte) == immutable(T)))
         hasher((cast(ubyte*)&record)[0 .. ubyte.sizeof]);
     else static if (is(immutable(T) == immutable(__c_ulonglong)))
@@ -159,6 +169,53 @@ public void hashPart (T) (scope const auto ref T record, scope HashDg hasher)
     else
         foreach (const ref field; record.tupleof)
             hashPart(field, hasher);
+}
+
+/*******************************************************************************
+
+    Hash the variable-length binary format of an unsigned integer
+
+    VarInt Size
+    size <= 0xFC(252)  -- 1 byte   ubyte
+    size <= USHORT_MAX -- 3 bytes  (0xFD + ushort)
+    size <= UINT_MAX   -- 5 bytes  (0xFE + uint)
+    size <= ULONG_MAX  -- 9 bytes  (0xFF + ulong)
+
+    Params:
+        T = Type of unsigned integer to hash
+        var = Instance of `T` to hash
+        dg  = Hash delegate
+
+    Returns:
+        The hashed variable length integer
+
+*******************************************************************************/
+
+private void hashVarInt (T) (const T var, scope HashDg hasher)
+    @trusted @nogc
+    if (isUnsigned!T)
+{
+    assert(var >= 0);
+    static immutable ubyte[] type = [0xFD, 0xFE, 0xFF];
+    if (var <= 0xFC)
+        hasher((cast(ubyte*)&(*cast(ubyte*)&var))[0 .. 1]);
+    else if (var <= ushort.max)
+    {
+        hasher(type[0..1]);
+        hasher((cast(ubyte*)&(*cast(ushort*)&var))[0 .. ushort.sizeof]);
+    }
+    else if (var <= uint.max)
+    {
+        hasher(type[1..2]);
+        hasher((cast(ubyte*)&(*cast(uint*)&var))[0 .. uint.sizeof]);
+    }
+    else if (var <= ulong.max)
+    {
+        hasher(type[2..3]);
+        hasher((cast(ubyte*)&(*cast(ulong*)&var))[0 .. ulong.sizeof]);
+    }
+    else
+        assert(0, "Hash failure. Array length too large.");
 }
 
 // Endianness test
@@ -186,9 +243,18 @@ nothrow @nogc @safe unittest
         0xD4, 0x00, 0x99, 0x23
     ];
     const abc_exp = Hash(hdata, /*isLittleEndian:*/ true);
-    assert(hashFull("abc") == abc_exp);
 
-    static struct Composed
+    // If we use a string of "abc" the length is also hashed so we use ComposedString
+    static struct ComposedString
+    {
+        char a;
+        char b;
+        char c;
+    }
+    Hash abc = hashFull(ComposedString('a', 'b', 'c'));
+    assert(abc == abc_exp);
+
+    static struct ComposedWithComputeHash
     {
         public char c0;
         private int irrelevant;
@@ -199,18 +265,14 @@ nothrow @nogc @safe unittest
 
         public void computeHash (scope HashDg dg) const nothrow @safe @nogc
         {
-            // We can hash in any order we want
-            hashPart(this.c0, dg);
-            hashPart(this.c1, dg);
+            // We can hash in any order we want so lets reverse the order and skip some fields
             hashPart(this.c2, dg);
+            hashPart(this.c1, dg);
+            hashPart(this.c0, dg);
         }
     }
-
-    Composed str;
-    str.c0 = 'a';
-    str.c1 = 'b';
-    str.c2 = 'c';
-    assert(hashFull(str) == abc_exp);
+    Hash cba = hashFull(ComposedWithComputeHash('c', 5, 'b', 42, 'a', "flute"));
+    assert(cba == abc_exp);
 }
 
 /*******************************************************************************
@@ -241,23 +303,23 @@ public Hash hashMulti (T...)(auto ref T args) nothrow @nogc @safe
 
     static foreach (idx, _; args)
         hashPart(args[idx], dg);
-    () @trusted { crypto_generichash_final(&state, hash[].ptr, Hash.sizeof); }();
+    void trusted () @trusted
+    {
+        crypto_generichash_final(&state, hash[].ptr, Hash.sizeof);
+    }
+    trusted();
     return hash;
 }
 
 ///
 nothrow @nogc @safe unittest
 {
-    Hash foo = hashFull("foo");
-    Hash bar = hashFull("bar");
-    const merged = Hash(
-        "0xe0343d063b14c52630563ec81b0f91a84ddb05f2cf05a2e4330ddc79bd3a06e57" ~
-        "c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74");
-
-    assert(hashMulti(foo, bar) == merged);
-
-    const Hash[2] array = [foo, bar];
-    assert(hashFull(array[]) == merged);
+    struct T
+    {
+        string foo;
+        string bar;
+    }
+    assert(hashFull(T("foo", "bar")) == hashMulti("foo", "bar"));
 
     static struct S
     {
@@ -279,4 +341,64 @@ nothrow @nogc @safe unittest
     auto hash_1 = hashMulti(420, "bpfk", S('a', 0, 'b', 0, 'c', 0));
     auto hash_2 = hashMulti(420, "bpfk", S('a', 1, 'b', 2, 'c', 3));
     assert(hash_1 == hash_2);
+
+    static struct X
+    {
+        T t;
+        S s;
+    }
+    auto s = S('a', 0, 'b', 0, 'c', 0);
+    auto hash_x1 = hashMulti(T("foo", "bar"), 'a', 'b', 'c');
+    auto hash_x2 = hashFull(X(T("foo", "bar"), s));
+    assert(hash_x1 == hash_x2, "Hash of nested struct with computeHash failed");
+}
+
+/// Test that array with struct inside will use computeHash
+unittest
+{
+    static struct S
+    {
+        public char c0;
+        private int unused_1;
+        public char c1;
+
+        public void computeHash (scope HashDg dg) const nothrow @safe @nogc
+        {
+            hashPart(this.c0, dg);
+            hashPart(this.c1, dg);
+        }
+    }
+    static struct X
+    {
+        string foo;
+        S[] x;
+    }
+    static struct X_S
+    {
+        string foo;
+        ubyte len;  // We need to simulate the array size being included
+        char c0;
+        char c1;
+    }
+    auto s1 = S('a', 42, 'b');
+    auto s = [ s1 ];
+    auto hash_x1 = hashFull(X_S("foo", 1, 'a', 'b'));
+    auto hash_x2 = hashFull(X("foo", s));
+    assert(hash_x1 == hash_x2, "Hash of struct in an array with computeHash failed");
+}
+
+// https://github.com/bpfkorea/agora/issues/1331
+unittest
+{
+    import std.format;
+
+    static struct S
+    {
+        ubyte[] arr1;
+        ubyte[] arr2;
+    }
+    auto s1 = S([0, 1, 2], null);
+    auto s2 = S(null, [0, 1, 2]);
+    assert(s1.hashFull() != s2.hashFull(),
+        format!"%s == %s"(s1, s2));
 }


### PR DESCRIPTION
This will include a hash of the array length of arrays being hashed. This is to prevent equivalent hash values for records with adjacent arrays creating unwanted hash collisions. See [issue #1331](https://github.com/bpfkorea/agora/issues/1331) in Agora.