### PR TITLE
Use scope const instead of 'in' for toString

### DIFF
--- a/source/agora/crypto/ECC.d
+++ b/source/agora/crypto/ECC.d
@@ -117,7 +117,7 @@ public struct Scalar
 
     ***************************************************************************/
 
-    public void toString (scope void delegate(in char[]) @safe sink,
+    public void toString (scope void delegate(scope const(char)[]) @safe sink,
                           PrintMode mode = PrintMode.Obfuscated) const @safe
     {
         final switch (mode)
@@ -136,7 +136,7 @@ public struct Scalar
     public string toString (PrintMode mode = PrintMode.Obfuscated) const @safe
     {
         string result;
-        this.toString((data) { result ~= data; }, mode);
+        this.toString((scope data) { result ~= data; }, mode);
         return result;
     }
 
@@ -304,7 +304,7 @@ public struct Point
     }
 
     /// Expose `toString`
-    public void toString (scope void delegate(in char[]) @safe dg)
+    public void toString (scope void delegate(scope const(char)[]) @safe dg)
         const @safe
     {
         this.data.toString(dg);


### PR DESCRIPTION
Due to an upstream bug, sink delegates with 'in' are not recognized by formattedWrite,
leading to allocation (as formattedWrite uses the string-returning overload).
Revert to 'scope const' until the bug is fixed.