### PR TITLE
Hash pointers like 1 element array

### DIFF
--- a/source/agora/crypto/Hash.d
+++ b/source/agora/crypto/Hash.d
@@ -166,6 +166,17 @@ public void hashPart (T) (scope const auto ref T record, scope HashDg hasher)
         foreach (ref r; record)
             hashPart(r, hasher);
     }
+    // Pointers are handled as arrays, only their size must be 0 or 1
+    else static if (is(T : E*, E))
+    {
+        if (record is null)
+            hashVarInt(uint(0), hasher);
+        else
+        {
+            hashVarInt(uint(1), hasher);
+            hashPart(*record, hasher);
+        }
+    }
     else static if (is(immutable(ubyte) == immutable(T)))
         hasher((cast(ubyte*)&record)[0 .. ubyte.sizeof]);
     else static if (is(immutable(T) == immutable(__c_ulonglong)))


### PR DESCRIPTION
This is to enable hashing structures which contain pointers. e.g. SCPStatement. It uses the same method as we use in Serializer and treats a pointer like an array of either zero or one length.