### PR TITLE
Remove multiSigSign and multiSigVerify

### DIFF
--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -183,7 +183,7 @@ public Signature sign (T) (in Pair kp, in Pair r, scope const auto ref T data)
 /// Complex API, allow multisig (not including multisig threshold)
 public Signature sign (T) (
     in Scalar x, in Point X, in Point R, in Scalar r, scope const auto ref T data)
-    nothrow @nogc @trusted
+    nothrow @nogc @safe
 {
     /*
       G := Generator point:
@@ -209,7 +209,7 @@ public Signature sign (T) (
 
 /// sign with prepared message hash `c` (used for multisig with threshold)
 public Signature sign (in Scalar x, in Point R, in Scalar r, in Scalar c)
-    nothrow @nogc @trusted
+    nothrow @nogc @safe
 {
     /*
       G := Generator point:
@@ -243,7 +243,7 @@ public Signature sign (in Scalar x, in Point R, in Scalar r, in Scalar c)
 *******************************************************************************/
 
 public bool verify (T) (in Point X, in Signature sig, scope const auto ref T data)
-    nothrow @nogc @trusted
+    nothrow @nogc @safe
 {
     // Compute the challenge and reduce the hash to a scalar
     Scalar c = hashFull(const(Message!T)(X, sig.R, data));
@@ -251,7 +251,7 @@ public bool verify (T) (in Point X, in Signature sig, scope const auto ref T dat
 }
 /// verify with predefined message hash `c` (required for threshold multisig)
 public bool verify (in Signature sig, in Scalar c, in Point X)
-    nothrow @nogc @trusted
+    nothrow @nogc @safe
 {
     // First check if Scalar from signature is valid
     if (!sig.s.isValid())

--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -96,14 +96,7 @@ nothrow @nogc @safe unittest
     assert(sig.R == R.V);
 }
 
-/*******************************************************************************
-    Represent a signature (R, s)
-
-    Note that signatures get passed around as binary blobs
-    (see `agora.common.Types`), so this type is named `Sig` to avoid ambiguity.
-
-*******************************************************************************/
-
+/// Represent a schnorr signature (R, s)
 public struct Signature
 {
     /// Commitment

--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -140,6 +140,15 @@ public struct Signature
         this.s = s;
     }
 
+    static Signature fromString (scope const(char)[] hex_str)
+    {
+        static const length = Point.sizeof + Scalar.sizeof;
+        const bytes = BitBlob!(length)(hex_str); // the bytes are little endian
+        const Point R = bytes[Scalar.sizeof .. length];
+        const Scalar s = bytes[0 .. Scalar.sizeof];
+        return Signature(R, s);
+    }
+
     unittest
     {
         import std.format;
@@ -151,6 +160,10 @@ public struct Signature
         const sig = Signature(R, s);
         assert(sig.R == R, sig.R.toString());
         assert(sig.s == s, sig.s.toString(PrintMode.Clear));
+        const signature = Signature.fromString("0x921405afbfa97813293770efd55865c01055f39ad2a70f2b7a04ac043766a693074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216");
+        assert(signature.R == sig.R, signature.R.toString);
+        assert(signature.s == sig.s, signature.s.toString(PrintMode.Clear));
+        assert(sig == signature);
     }
 }
 

--- a/source/agora/crypto/Schnorr.d
+++ b/source/agora/crypto/Schnorr.d
@@ -87,30 +87,13 @@ nothrow @nogc @safe unittest
     assert(verify(X, sig3, secret));
 }
 
-/*******************************************************************************
-
-    Extract the R from (R, s) of a binary representation of a signature
-
-    Params:
-        sig = the binary representation of the schnorr signature
-
-    Returns:
-        the R from the (R, s) pair
-
-*******************************************************************************/
-
-public Point extractNonce (Signature sig) @safe @nogc nothrow pure
-{
-    return sig.R;
-}
-
 ///
 @safe @nogc nothrow /*pure*/ unittest
 {
     const R = Pair.random();
     const kp = Pair.random();
     const sig = sign(kp.v, kp.V, R.V, R.v, "foo");
-    assert(extractNonce(sig) == R.V);
+    assert(sig.R == R.V);
 }
 
 /*******************************************************************************

--- a/source/agora/crypto/Types.d
+++ b/source/agora/crypto/Types.d
@@ -22,15 +22,11 @@ import geod24.bitblob;
 /// 512 bits hash type computed via `BLAKE2b`
 public alias Hash = BitBlob!64;
 
-/// The type of a signature
-public alias Signature = BitBlob!64;
-
 unittest
 {
     // Check that our type match libsodium's definition
     import libsodium;
 
-    static assert(Signature.sizeof == crypto_sign_ed25519_BYTES);
     static assert(Hash.sizeof == crypto_generichash_BYTES_MAX);
 }
 


### PR DESCRIPTION
Replacing special functions for threshold multisig with use of new
`sign` and `verify` overloads. This is to make the code easier to reason
about.