### PR TITLE
Scalar, Point: Use inout on opSlice

### DIFF
--- a/source/agora/crypto/ECC.d
+++ b/source/agora/crypto/ECC.d
@@ -276,8 +276,8 @@ public struct Scalar
         return ret;
     }
 
-    /// Convenience overload to allow this to be converted to a BitBlob
-    public const(ubyte)[] opSlice () const pure
+    /// Convenience overload to allow this to be passed to libsodium & co
+    public inout(ubyte)[] opSlice () inout pure
     {
         return this.data[];
     }
@@ -406,8 +406,8 @@ public struct Point
         return result;
     }
 
-    /// Convenience overload to allow this to be converted to a `PublicKey`
-    public const(ubyte)[] opSlice () const pure
+    /// Convenience overload to allow this to be passed to libsodium & co
+    public inout(ubyte)[] opSlice () inout pure
     {
         return this.data[];
     }


### PR DESCRIPTION
Since we need to pass those to libsodium sometimes,
and the underlying BitBlob exposes those as inout,
there's no reason to force const.