### PR TITLE
Make hashing pure

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,6 +16,6 @@
 
     "dependencies": {
         "bitblob":    { "version": "~>2.2",          "dflags": [ "-preview=in" ] },
-        "libsodiumd": { "version": "~>0.1.1+1.0.18", "dflags": [ "-preview=in" ] }
+        "libsodiumd": { "version": "~>0.2.0+1.0.18", "dflags": [ "-preview=in" ] }
     }
 }


### PR DESCRIPTION
Hashing is a pure operation, hence this commit does:
- Update to a new version of libsodiumd which have the correct attributes;
- Remove some @trusted workaround as the new version also exposes `@safe` wrappers;
- Add `pure` where needed;
- Add `scope` on function, for completeness;
- Unify the style;